### PR TITLE
Standardize file name and path methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.7.1
 before_install: gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## 0.0.13
 
-- *BREAKING CHANGE*: Make Everything.path an instance of Pathname
+- **BREAKING CHANGE**: Make Everything.path an instance of Pathname
 - Add #absolute_dir, #absolute_path, #dir, #file_name, #path to Everything::Piece
 - Memoize Everything::Piece#name
 - Add #absolute_dir, #absolute_path, #dir, #path to Everything::Piece::Content
 - Add #absolute_dir, #absolute_path, #dir, #path to Everything::Piece::Metadata
 - Deprecate #file_path on Everything::Piece::Content and Everything::Piece::Metadata
+- Use Pathname convenience methods when working with files and paths internally
 
 ## 0.0.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.0.13
+
+- *BREAKING CHANGE*: Make Everything.path an instance of Pathname
+- Add #absolute_dir, #absolute_path, #dir, #path to Everything::Piece
+- Add #absolute_dir, #absolute_path, #dir, #path to Everything::Piece::Content
+- Add #absolute_dir, #absolute_path, #dir, #path to Everything::Piece::Metadata
+- Deprecate #file_path on Everything::Piece::Content and Everything::Piece::Metadata
+
 ## 0.0.12
 
 - Add an Everything logger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 0.0.13
 
 - *BREAKING CHANGE*: Make Everything.path an instance of Pathname
-- Add #absolute_dir, #absolute_path, #dir, #path to Everything::Piece
+- Add #absolute_dir, #absolute_path, #dir, #file_name, #path to Everything::Piece
+- Memoize Everything::Piece#name
 - Add #absolute_dir, #absolute_path, #dir, #path to Everything::Piece::Content
 - Add #absolute_dir, #absolute_path, #dir, #path to Everything::Piece::Metadata
 - Deprecate #file_path on Everything::Piece::Content and Everything::Piece::Metadata

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ and content.
 ```ruby
 require 'everything'
 
-piece_path = File.join(Everything.path, 'your-piece-here')
+piece_path = Everything.path.join('your-piece-here')
 piece      = Everything::Piece.new(piece_path)
 
 piece.name          # => 'your-piece-here'

--- a/everything-core.gemspec
+++ b/everything-core.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 13.0.1'
   spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'timecop', '~> 0.9'
-  spec.add_development_dependency 'fakefs'
+  spec.add_development_dependency 'fakefs', '~> 1.2.2'
 end
 

--- a/everything-core.gemspec
+++ b/everything-core.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 13.0.1'
   spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'timecop', '~> 0.9'
+  spec.add_development_dependency 'fakefs'
 end
 

--- a/lib/everything.rb
+++ b/lib/everything.rb
@@ -1,6 +1,7 @@
 require 'dotenv'
 Dotenv.load
 
+require 'pathname'
 require 'fastenv'
 require 'everything/version'
 require 'everything/logger'
@@ -8,7 +9,7 @@ require 'everything/piece'
 
 module Everything
   def self.path
-    Fastenv.everything_path
+    Pathname.new(Fastenv.everything_path)
   end
 end
 

--- a/lib/everything/piece.rb
+++ b/lib/everything/piece.rb
@@ -24,7 +24,8 @@ module Everything
       @dir ||= calculated_dir
     end
 
-    def_delegators :content, :body, :raw_markdown, :raw_markdown=, :title
+
+    def_delegators :content, :body, :file_name, :raw_markdown, :raw_markdown=, :title
 
     def metadata
       @metadata ||= Metadata.new(full_path)

--- a/lib/everything/piece.rb
+++ b/lib/everything/piece.rb
@@ -6,12 +6,22 @@ module Everything
 
     attr_reader :full_path
 
+    # TODO: Add the following methods:
+    #   - dir (Relative to Everything.path)
+    #   - path (Relative to Everything.path)
+    #   - absolute_dir
+    #   - absolute_path
+
     def initialize(full_path)
       @full_path = full_path
     end
 
     def content
       @content ||= Content.new(full_path)
+    end
+
+    def dir
+      @dir ||= calculated_dir
     end
 
     def_delegators :content, :body, :raw_markdown, :raw_markdown=, :title
@@ -33,6 +43,15 @@ module Everything
     def save
       content.save
       metadata.save
+    end
+
+  private
+
+    def calculated_dir
+      everything_pathname = Pathname.new(Everything.path)
+      full_pathname = Pathname.new(full_path)
+      relative_pathname = full_pathname.relative_path_from(everything_pathname)
+      relative_pathname.to_s
     end
   end
 end

--- a/lib/everything/piece.rb
+++ b/lib/everything/piece.rb
@@ -26,7 +26,6 @@ module Everything
       @dir ||= calculated_dir
     end
 
-
     def_delegators :content, :body, :file_name, :raw_markdown, :raw_markdown=, :title
 
     def metadata

--- a/lib/everything/piece.rb
+++ b/lib/everything/piece.rb
@@ -20,6 +20,10 @@ module Everything
       @absolute_dir ||= File.join(Everything.path, dir)
     end
 
+    def absolute_path
+      @absolute_path ||= File.join(absolute_dir, file_name)
+    end
+
     def content
       @content ||= Content.new(full_path)
     end

--- a/lib/everything/piece.rb
+++ b/lib/everything/piece.rb
@@ -10,23 +10,11 @@ module Everything
       @full_path = full_path
     end
 
-    def absolute_dir
-      @absolute_dir ||= File.join(Everything.path, dir)
-    end
-
-    def absolute_path
-      @absolute_path ||= File.join(absolute_dir, file_name)
-    end
-
     def content
       @content ||= Content.new(full_path)
     end
 
-    def dir
-      @dir ||= calculated_dir
-    end
-
-    def_delegators :content, :body, :file_name, :raw_markdown, :raw_markdown=, :title
+    def_delegators :content, :absolute_dir, :absolute_path, :body, :dir, :file_name, :path, :raw_markdown, :raw_markdown=, :title
 
     def metadata
       @metadata ||= Metadata.new(full_path)
@@ -42,22 +30,9 @@ module Everything
       @name ||= File.basename(full_path)
     end
 
-    def path
-      @path ||= File.join(dir, content.file_name)
-    end
-
     def save
       content.save
       metadata.save
-    end
-
-  private
-
-    def calculated_dir
-      everything_pathname = Pathname.new(Everything.path)
-      full_pathname = Pathname.new(full_path)
-      relative_pathname = full_pathname.relative_path_from(everything_pathname)
-      relative_pathname.to_s
     end
   end
 end

--- a/lib/everything/piece.rb
+++ b/lib/everything/piece.rb
@@ -16,6 +16,10 @@ module Everything
       @full_path = full_path
     end
 
+    def absolute_dir
+      @absolute_dir ||= File.join(Everything.path, dir)
+    end
+
     def content
       @content ||= Content.new(full_path)
     end

--- a/lib/everything/piece.rb
+++ b/lib/everything/piece.rb
@@ -6,12 +6,6 @@ module Everything
 
     attr_reader :full_path
 
-    # TODO: Add the following methods:
-    #   - dir (Relative to Everything.path)
-    #   - path (Relative to Everything.path)
-    #   - absolute_dir
-    #   - absolute_path
-
     def initialize(full_path)
       @full_path = full_path
     end

--- a/lib/everything/piece.rb
+++ b/lib/everything/piece.rb
@@ -37,7 +37,11 @@ module Everything
     def_delegators :metadata, :raw_yaml, :raw_yaml=
 
     def name
-      File.basename(full_path)
+      @name ||= File.basename(full_path)
+    end
+
+    def path
+      @path ||= File.join(dir, content.file_name)
     end
 
     def save

--- a/lib/everything/piece/content.rb
+++ b/lib/everything/piece/content.rb
@@ -7,6 +7,10 @@ module Everything
         @piece_path = piece_path
       end
 
+      def dir
+        @dir ||= calculated_dir
+      end
+
       def file_name
         'index.md'
       end
@@ -42,6 +46,13 @@ module Everything
 
       def partitioned_text
         @partitioned_text ||= raw_markdown.partition("\n\n")
+      end
+
+      def calculated_dir
+        everything_pathname = Pathname.new(Everything.path)
+        full_pathname = Pathname.new(piece_path)
+        relative_pathname = full_pathname.relative_path_from(everything_pathname)
+        relative_pathname.to_s
       end
     end
   end

--- a/lib/everything/piece/content.rb
+++ b/lib/everything/piece/content.rb
@@ -11,6 +11,10 @@ module Everything
         @absolute_dir ||= File.join(Everything.path, dir)
       end
 
+      def absolute_path
+        @absolute_path ||= File.join(absolute_dir, file_name)
+      end
+
       def dir
         @dir ||= calculated_dir
       end

--- a/lib/everything/piece/content.rb
+++ b/lib/everything/piece/content.rb
@@ -24,6 +24,9 @@ module Everything
       end
 
       def file_path
+        # TODO: Could try a deprecation approach like http://seejohncode.com/2012/01/09/deprecating-methods-in-ruby/
+        deprecation_message = "Piece Content's #file_path is deprecated and will be removed soon. Use #absolute_path instead."
+        warn deprecation_message
         @file_path ||= File.join(piece_path, file_name)
       end
 

--- a/lib/everything/piece/content.rb
+++ b/lib/everything/piece/content.rb
@@ -8,11 +8,11 @@ module Everything
       end
 
       def absolute_dir
-        @absolute_dir ||= File.join(Everything.path, dir)
+        @absolute_dir ||= Everything.path.join(dir)
       end
 
       def absolute_path
-        @absolute_path ||= File.join(absolute_dir, file_name)
+        @absolute_path ||= absolute_dir.join(file_name)
       end
 
       def dir
@@ -39,7 +39,7 @@ module Everything
       end
 
       def path
-        @path ||= File.join(dir, file_name)
+        @path ||= dir.join(file_name)
       end
 
       def raw_markdown
@@ -64,10 +64,8 @@ module Everything
       end
 
       def calculated_dir
-        everything_pathname = Pathname.new(Everything.path)
         full_pathname = Pathname.new(piece_path)
-        relative_pathname = full_pathname.relative_path_from(everything_pathname)
-        relative_pathname.to_s
+        _relative_pathname = full_pathname.relative_path_from(Everything.path)
       end
     end
   end

--- a/lib/everything/piece/content.rb
+++ b/lib/everything/piece/content.rb
@@ -46,3 +46,4 @@ module Everything
     end
   end
 end
+

--- a/lib/everything/piece/content.rb
+++ b/lib/everything/piece/content.rb
@@ -7,6 +7,10 @@ module Everything
         @piece_path = piece_path
       end
 
+      def absolute_dir
+        @absolute_dir ||= File.join(Everything.path, dir)
+      end
+
       def dir
         @dir ||= calculated_dir
       end

--- a/lib/everything/piece/content.rb
+++ b/lib/everything/piece/content.rb
@@ -43,7 +43,7 @@ module Everything
       end
 
       def raw_markdown
-        @raw_markdown ||= File.read(absolute_path)
+        @raw_markdown ||= absolute_path.read
       end
 
       def raw_markdown=(value)
@@ -53,7 +53,7 @@ module Everything
       def save
         FileUtils.mkdir_p(piece_path)
 
-        File.write(absolute_path, @raw_markdown)
+        absolute_path.write(@raw_markdown)
       end
 
     private

--- a/lib/everything/piece/content.rb
+++ b/lib/everything/piece/content.rb
@@ -43,7 +43,7 @@ module Everything
       end
 
       def raw_markdown
-        @raw_markdown ||= File.read(file_path)
+        @raw_markdown ||= File.read(absolute_path)
       end
 
       def raw_markdown=(value)
@@ -53,7 +53,7 @@ module Everything
       def save
         FileUtils.mkdir_p(piece_path)
 
-        File.write(file_path, @raw_markdown)
+        File.write(absolute_path, @raw_markdown)
       end
 
     private

--- a/lib/everything/piece/content.rb
+++ b/lib/everything/piece/content.rb
@@ -27,6 +27,10 @@ module Everything
         partitioned_text.last
       end
 
+      def path
+        @path ||= File.join(dir, file_name)
+      end
+
       def raw_markdown
         @raw_markdown ||= File.read(file_path)
       end

--- a/lib/everything/piece/metadata.rb
+++ b/lib/everything/piece/metadata.rb
@@ -23,6 +23,10 @@ module Everything
         @file_path ||= File.join(piece_path, file_name)
       end
 
+      def path
+        @path ||= File.join(dir, file_name)
+      end
+
       def raw_yaml
         @raw_yaml ||= YAML.load_file(file_path)
       end

--- a/lib/everything/piece/metadata.rb
+++ b/lib/everything/piece/metadata.rb
@@ -39,7 +39,7 @@ module Everything
       end
 
       def raw_yaml
-        @raw_yaml ||= YAML.load_file(file_path)
+        @raw_yaml ||= YAML.load_file(absolute_path)
       end
 
       def raw_yaml=(value)
@@ -49,7 +49,7 @@ module Everything
       def save
         FileUtils.mkdir_p(piece_path)
 
-        File.write(file_path, @raw_yaml)
+        File.write(absolute_path, @raw_yaml)
       end
 
       def_delegators :raw_yaml, :[]

--- a/lib/everything/piece/metadata.rb
+++ b/lib/everything/piece/metadata.rb
@@ -28,6 +28,9 @@ module Everything
       end
 
       def file_path
+        # TODO: Could try a deprecation approach like http://seejohncode.com/2012/01/09/deprecating-methods-in-ruby/
+        deprecation_message = "Piece Metadata's #file_path is deprecated and will be removed soon. Use #absolute_path instead."
+        warn deprecation_message
         @file_path ||= File.join(piece_path, file_name)
       end
 

--- a/lib/everything/piece/metadata.rb
+++ b/lib/everything/piece/metadata.rb
@@ -15,6 +15,10 @@ module Everything
         @piece_path = piece_path
       end
 
+      def absolute_dir
+        @absolute_dir ||= File.join(Everything.path, dir)
+      end
+
       def dir
         @dir ||= calculated_dir
       end

--- a/lib/everything/piece/metadata.rb
+++ b/lib/everything/piece/metadata.rb
@@ -49,7 +49,7 @@ module Everything
       def save
         FileUtils.mkdir_p(piece_path)
 
-        File.write(absolute_path, @raw_yaml)
+        absolute_path.write(@raw_yaml)
       end
 
       def_delegators :raw_yaml, :[]

--- a/lib/everything/piece/metadata.rb
+++ b/lib/everything/piece/metadata.rb
@@ -15,6 +15,10 @@ module Everything
         @piece_path = piece_path
       end
 
+      def dir
+        @dir ||= calculated_dir
+      end
+
       def file_path
         @file_path ||= File.join(piece_path, file_name)
       end
@@ -40,6 +44,13 @@ module Everything
 
       def file_name
         'index.yaml'
+      end
+
+      def calculated_dir
+        everything_pathname = Pathname.new(Everything.path)
+        full_pathname = Pathname.new(piece_path)
+        relative_pathname = full_pathname.relative_path_from(everything_pathname)
+        relative_pathname.to_s
       end
     end
   end

--- a/lib/everything/piece/metadata.rb
+++ b/lib/everything/piece/metadata.rb
@@ -19,6 +19,10 @@ module Everything
         @absolute_dir ||= File.join(Everything.path, dir)
       end
 
+      def absolute_path
+        @absolute_path ||= File.join(absolute_dir, file_name)
+      end
+
       def dir
         @dir ||= calculated_dir
       end

--- a/lib/everything/piece/metadata.rb
+++ b/lib/everything/piece/metadata.rb
@@ -16,11 +16,11 @@ module Everything
       end
 
       def absolute_dir
-        @absolute_dir ||= File.join(Everything.path, dir)
+        @absolute_dir ||= Everything.path.join(dir)
       end
 
       def absolute_path
-        @absolute_path ||= File.join(absolute_dir, file_name)
+        @absolute_path ||= absolute_dir.join(file_name)
       end
 
       def dir
@@ -35,7 +35,7 @@ module Everything
       end
 
       def path
-        @path ||= File.join(dir, file_name)
+        @path ||= dir.join(file_name)
       end
 
       def raw_yaml
@@ -62,10 +62,8 @@ module Everything
       end
 
       def calculated_dir
-        everything_pathname = Pathname.new(Everything.path)
         full_pathname = Pathname.new(piece_path)
-        relative_pathname = full_pathname.relative_path_from(everything_pathname)
-        relative_pathname.to_s
+        _relative_pathname = full_pathname.relative_path_from(Everything.path)
       end
     end
   end

--- a/lib/everything/version.rb
+++ b/lib/everything/version.rb
@@ -1,3 +1,3 @@
 module Everything
-  VERSION = '0.0.12'
+  VERSION = '0.0.13'
 end

--- a/spec/everything/piece/content_spec.rb
+++ b/spec/everything/piece/content_spec.rb
@@ -23,6 +23,21 @@ describe Everything::Piece::Content do
     end
   end
 
+  describe '#absolute_path' do
+    let(:content_absolute_path) do
+      '/fake/everything/path/grond-crawled-on/index.md'
+    end
+    it "returns the content's absolute path" do
+      expect(content.absolute_path).to eq(content_absolute_path)
+    end
+
+    it 'memoizes the value' do
+      first_call_result = content.absolute_path
+      second_call_result = content.absolute_path
+      expect(first_call_result.object_id).to eq(second_call_result.object_id)
+    end
+  end
+
   describe '#dir' do
     let(:content_dir_relative_to_everything_path) do
       'grond-crawled-on'

--- a/spec/everything/piece/content_spec.rb
+++ b/spec/everything/piece/content_spec.rb
@@ -101,7 +101,7 @@ MD
     end
   end
 
-  xdescribe '#path' do
+  describe '#path' do
     let(:content_path_relative_to_everything_path) do
       'grond-crawled-on/index.md'
     end

--- a/spec/everything/piece/content_spec.rb
+++ b/spec/everything/piece/content_spec.rb
@@ -12,6 +12,7 @@ describe Everything::Piece::Content do
     let(:content_absolute_dir) do
       Pathname.new('/fake/everything/path/grond-crawled-on')
     end
+
     it "returns the content's absolute path" do
       expect(content.absolute_dir).to eq(content_absolute_dir)
     end
@@ -27,6 +28,7 @@ describe Everything::Piece::Content do
     let(:content_absolute_path) do
       Pathname.new('/fake/everything/path/grond-crawled-on/index.md')
     end
+
     it "returns the content's absolute path" do
       expect(content.absolute_path).to eq(content_absolute_path)
     end
@@ -42,6 +44,7 @@ describe Everything::Piece::Content do
     let(:content_dir_relative_to_everything_path) do
       Pathname.new('grond-crawled-on')
     end
+
     it "returns the content's path relative to everything path" do
       expect(content.dir).to eq(content_dir_relative_to_everything_path)
     end

--- a/spec/everything/piece/content_spec.rb
+++ b/spec/everything/piece/content_spec.rb
@@ -132,13 +132,13 @@ MD
     end
 
     it 'memoizes the file read' do
-      allow(File)
+      allow(content.absolute_path)
         .to receive(:read)
         .and_call_original
 
       2.times { content.raw_markdown }
 
-      expect(File)
+      expect(content.absolute_path)
         .to have_received(:read)
         .exactly(:once)
     end
@@ -179,54 +179,54 @@ MD
       end
 
       it 'creates the folder' do
-        expect(Dir.exist?(fake_piece_path)).to eq(false)
+        expect(fake_piece_path).not_to exist
 
         content.save
 
-        expect(Dir.exist?(fake_piece_path)).to eq(true)
+        expect(fake_piece_path).to exist
       end
 
       it 'creates the content markdown file' do
-        expect(File.exist?(content.absolute_path)).to eq(false)
+        expect(content.absolute_path).not_to exist
 
         content.save
 
-        expect(File.exist?(content.absolute_path)).to eq(true)
+        expect(content.absolute_path).to exist
       end
 
       it 'writes the markdown to the file' do
         content.save
 
-        expect(File.read(content.absolute_path)).to eq('# Ship Shape')
+        expect(content.absolute_path.read).to eq('# Ship Shape')
       end
     end
 
     context 'when the piece directory exists' do
       context 'when the content file does not exist' do
         it 'creates the content markdown file' do
-          expect(File.exist?(content.absolute_path)).to eq(false)
+          expect(content.absolute_path).not_to exist
 
           content.save
 
-          expect(File.exist?(content.absolute_path)).to eq(true)
+          expect(content.absolute_path).to exist
         end
 
         it 'writes the markdown to the file' do
           content.save
 
-          expect(File.read(content.absolute_path)).to eq('# Ship Shape')
+          expect(content.absolute_path.read).to eq('# Ship Shape')
         end
       end
 
       context 'when the content file already exists' do
         before do
-          File.write(content.absolute_path, '# Rolly Polly')
+          content.absolute_path.write('# Rolly Polly')
         end
 
         it 'overwrites the file with the correct markdown' do
           content.save
 
-          expect(File.read(content.absolute_path)).to eq('# Ship Shape')
+          expect(content.absolute_path.read).to eq('# Ship Shape')
         end
       end
     end

--- a/spec/everything/piece/content_spec.rb
+++ b/spec/everything/piece/content_spec.rb
@@ -184,46 +184,46 @@ MD
       end
 
       it 'creates the content markdown file' do
-        expect(File.exist?(content.file_path)).to eq(false)
+        expect(File.exist?(content.absolute_path)).to eq(false)
 
         content.save
 
-        expect(File.exist?(content.file_path)).to eq(true)
+        expect(File.exist?(content.absolute_path)).to eq(true)
       end
 
       it 'writes the markdown to the file' do
         content.save
 
-        expect(File.read(content.file_path)).to eq('# Ship Shape')
+        expect(File.read(content.absolute_path)).to eq('# Ship Shape')
       end
     end
 
     context 'when the piece directory exists' do
       context 'when the content file does not exist' do
         it 'creates the content markdown file' do
-          expect(File.exist?(content.file_path)).to eq(false)
+          expect(File.exist?(content.absolute_path)).to eq(false)
 
           content.save
 
-          expect(File.exist?(content.file_path)).to eq(true)
+          expect(File.exist?(content.absolute_path)).to eq(true)
         end
 
         it 'writes the markdown to the file' do
           content.save
 
-          expect(File.read(content.file_path)).to eq('# Ship Shape')
+          expect(File.read(content.absolute_path)).to eq('# Ship Shape')
         end
       end
 
       context 'when the content file already exists' do
         before do
-          File.write(content.file_path, '# Rolly Polly')
+          File.write(content.absolute_path, '# Rolly Polly')
         end
 
         it 'overwrites the file with the correct markdown' do
           content.save
 
-          expect(File.read(content.file_path)).to eq('# Ship Shape')
+          expect(File.read(content.absolute_path)).to eq('# Ship Shape')
         end
       end
     end

--- a/spec/everything/piece/content_spec.rb
+++ b/spec/everything/piece/content_spec.rb
@@ -10,7 +10,7 @@ describe Everything::Piece::Content do
 
   describe '#absolute_dir' do
     let(:content_absolute_dir) do
-      '/fake/everything/path/grond-crawled-on'
+      Pathname.new('/fake/everything/path/grond-crawled-on')
     end
     it "returns the content's absolute path" do
       expect(content.absolute_dir).to eq(content_absolute_dir)
@@ -25,7 +25,7 @@ describe Everything::Piece::Content do
 
   describe '#absolute_path' do
     let(:content_absolute_path) do
-      '/fake/everything/path/grond-crawled-on/index.md'
+      Pathname.new('/fake/everything/path/grond-crawled-on/index.md')
     end
     it "returns the content's absolute path" do
       expect(content.absolute_path).to eq(content_absolute_path)
@@ -40,7 +40,7 @@ describe Everything::Piece::Content do
 
   describe '#dir' do
     let(:content_dir_relative_to_everything_path) do
-      'grond-crawled-on'
+      Pathname.new('grond-crawled-on')
     end
     it "returns the content's path relative to everything path" do
       expect(content.dir).to eq(content_dir_relative_to_everything_path)
@@ -103,7 +103,7 @@ MD
 
   describe '#path' do
     let(:content_path_relative_to_everything_path) do
-      'grond-crawled-on/index.md'
+      Pathname.new('grond-crawled-on/index.md')
     end
 
     it "returns the content's path relative to everything path" do

--- a/spec/everything/piece/content_spec.rb
+++ b/spec/everything/piece/content_spec.rb
@@ -9,8 +9,6 @@ describe Everything::Piece::Content do
   end
 
   describe '#file_name' do
-    include_context 'with fake piece'
-
     let(:expected_file_name) do
       'index.md'
     end
@@ -21,8 +19,6 @@ describe Everything::Piece::Content do
   end
 
   describe '#file_path' do
-    include_context 'with fake piece'
-
     let(:expected_file_path) do
       "#{fake_piece_path}/index.md"
     end
@@ -85,8 +81,6 @@ MD
   end
 
   describe '#raw_markdown=' do
-    include_context 'with fake piece'
-
     let(:new_raw_markdown) do
       <<MD
 # New Markdown
@@ -103,8 +97,6 @@ MD
   end
 
   describe '#save' do
-    include_context 'with fake piece'
-
     before do
       FakeFS.activate!
 
@@ -176,3 +168,4 @@ MD
     end
   end
 end
+

--- a/spec/everything/piece/content_spec.rb
+++ b/spec/everything/piece/content_spec.rb
@@ -71,6 +71,22 @@ MD
     end
   end
 
+  xdescribe '#path' do
+    let(:content_path_relative_to_everything_path) do
+      'grond-crawled-on/index.md'
+    end
+
+    it "returns the content's path relative to everything path" do
+      expect(content.path).to eq(content_path_relative_to_everything_path)
+    end
+
+    it 'memoizes the value' do
+      first_path_value = content.path
+      second_path_value = content.path
+      expect(first_path_value.object_id).to eq(second_path_value.object_id)
+    end
+  end
+
   describe '#raw_markdown' do
     include_context 'with fake piece content'
 

--- a/spec/everything/piece/content_spec.rb
+++ b/spec/everything/piece/content_spec.rb
@@ -8,6 +8,21 @@ describe Everything::Piece::Content do
     described_class.new(fake_piece_path)
   end
 
+  describe '#absolute_dir' do
+    let(:content_absolute_dir) do
+      '/fake/everything/path/grond-crawled-on'
+    end
+    it "returns the content's absolute path" do
+      expect(content.absolute_dir).to eq(content_absolute_dir)
+    end
+
+    it 'memoizes the value' do
+      first_call_result = content.absolute_dir
+      second_call_result = content.absolute_dir
+      expect(first_call_result.object_id).to eq(second_call_result.object_id)
+    end
+  end
+
   describe '#dir' do
     let(:content_dir_relative_to_everything_path) do
       'grond-crawled-on'

--- a/spec/everything/piece/content_spec.rb
+++ b/spec/everything/piece/content_spec.rb
@@ -8,6 +8,21 @@ describe Everything::Piece::Content do
     described_class.new(fake_piece_path)
   end
 
+  describe '#dir' do
+    let(:content_dir_relative_to_everything_path) do
+      'grond-crawled-on'
+    end
+    it "returns the content's path relative to everything path" do
+      expect(content.dir).to eq(content_dir_relative_to_everything_path)
+    end
+
+    it 'memoizes the value' do
+      first_dir_value = content.dir
+      second_dir_value = content.dir
+      expect(first_dir_value.object_id).to eq(second_dir_value.object_id)
+    end
+  end
+
   describe '#file_name' do
     let(:expected_file_name) do
       'index.md'

--- a/spec/everything/piece/metadata_spec.rb
+++ b/spec/everything/piece/metadata_spec.rb
@@ -32,6 +32,8 @@ describe Everything::Piece::Metadata do
   end
 
   describe '#absolute_dir' do
+    include_context 'with fake piece metadata'
+
     let(:metadata_absolute_dir) do
       '/fake/everything/path/grond-crawled-on'
     end
@@ -47,6 +49,8 @@ describe Everything::Piece::Metadata do
   end
 
   describe '#absolute_path' do
+    include_context 'with fake piece metadata'
+
     let(:metadata_absolute_path) do
       '/fake/everything/path/grond-crawled-on/index.yaml'
     end

--- a/spec/everything/piece/metadata_spec.rb
+++ b/spec/everything/piece/metadata_spec.rb
@@ -60,6 +60,24 @@ describe Everything::Piece::Metadata do
     end
   end
 
+  describe '#path' do
+    include_context 'with fake piece metadata'
+
+    let(:metadata_path_relative_to_everything_path) do
+      'grond-crawled-on/index.yaml'
+    end
+
+    it "returns the metadata's path relative to everything path" do
+      expect(metadata.path).to eq(metadata_path_relative_to_everything_path)
+    end
+
+    it 'memoizes the value' do
+      first_path_value = metadata.path
+      second_path_value = metadata.path
+      expect(first_path_value.object_id).to eq(second_path_value.object_id)
+    end
+  end
+
   describe '#raw_yaml' do
     include_context 'with fake piece metadata'
 

--- a/spec/everything/piece/metadata_spec.rb
+++ b/spec/everything/piece/metadata_spec.rb
@@ -35,7 +35,7 @@ describe Everything::Piece::Metadata do
     include_context 'with fake piece metadata'
 
     let(:metadata_absolute_dir) do
-      '/fake/everything/path/grond-crawled-on'
+      Pathname.new('/fake/everything/path/grond-crawled-on')
     end
     it "returns the metadata's absolute path" do
       expect(metadata.absolute_dir).to eq(metadata_absolute_dir)
@@ -52,7 +52,7 @@ describe Everything::Piece::Metadata do
     include_context 'with fake piece metadata'
 
     let(:metadata_absolute_path) do
-      '/fake/everything/path/grond-crawled-on/index.yaml'
+      Pathname.new('/fake/everything/path/grond-crawled-on/index.yaml')
     end
     it "returns the metadata's absolute path" do
       expect(metadata.absolute_path).to eq(metadata_absolute_path)
@@ -69,7 +69,7 @@ describe Everything::Piece::Metadata do
     include_context 'with fake piece metadata'
 
     let(:metadata_dir_relative_to_everything_path) do
-      'grond-crawled-on'
+      Pathname.new('grond-crawled-on')
     end
     it "returns the metadata's path relative to everything path" do
       expect(metadata.dir).to eq(metadata_dir_relative_to_everything_path)
@@ -98,7 +98,7 @@ describe Everything::Piece::Metadata do
     include_context 'with fake piece metadata'
 
     let(:metadata_path_relative_to_everything_path) do
-      'grond-crawled-on/index.yaml'
+      Pathname.new('grond-crawled-on/index.yaml')
     end
 
     it "returns the metadata's path relative to everything path" do

--- a/spec/everything/piece/metadata_spec.rb
+++ b/spec/everything/piece/metadata_spec.rb
@@ -31,6 +31,23 @@ describe Everything::Piece::Metadata do
     end
   end
 
+  describe '#dir' do
+    include_context 'with fake piece metadata'
+
+    let(:metadata_dir_relative_to_everything_path) do
+      'grond-crawled-on'
+    end
+    it "returns the metadata's path relative to everything path" do
+      expect(metadata.dir).to eq(metadata_dir_relative_to_everything_path)
+    end
+
+    it 'memoizes the value' do
+      first_dir_value = metadata.dir
+      second_dir_value = metadata.dir
+      expect(first_dir_value.object_id).to eq(second_dir_value.object_id)
+    end
+  end
+
   describe '#file_path' do
     include_context 'with fake piece'
 

--- a/spec/everything/piece/metadata_spec.rb
+++ b/spec/everything/piece/metadata_spec.rb
@@ -184,25 +184,25 @@ YAML
       end
 
       it 'creates the folder' do
-        expect(Dir.exist?(fake_piece_path)).to eq(false)
+        expect(fake_piece_path).not_to exist
 
         metadata.save
 
-        expect(Dir.exist?(fake_piece_path)).to eq(true)
+        expect(fake_piece_path).to exist
       end
 
       it 'creates the metadata yaml file' do
-        expect(File.exist?(metadata.absolute_path)).to eq(false)
+        expect(metadata.absolute_path).not_to exist
 
         metadata.save
 
-        expect(File.exist?(metadata.absolute_path)).to eq(true)
+        expect(metadata.absolute_path).to exist
       end
 
       it 'writes the yaml to the file' do
         metadata.save
 
-        expect(File.read(metadata.absolute_path)).to eq(<<YAML)
+        expect(metadata.absolute_path.read).to eq(<<YAML)
 ---
 favorite_color: blue
 YAML
@@ -212,17 +212,17 @@ YAML
     context 'when the piece directory exists' do
       context 'when the metadata file does not exist' do
         it 'creates the metadata yaml file' do
-          expect(File.exist?(metadata.absolute_path)).to eq(false)
+          expect(metadata.absolute_path).not_to exist
 
           metadata.save
 
-          expect(File.exist?(metadata.absolute_path)).to eq(true)
+          expect(metadata.absolute_path).to exist
         end
 
         it 'writes the yaml to the file' do
           metadata.save
 
-          expect(File.read(metadata.absolute_path)).to eq(<<YAML)
+          expect(metadata.absolute_path.read).to eq(<<YAML)
 ---
 favorite_color: blue
 YAML
@@ -231,13 +231,13 @@ YAML
 
       context 'when the metadata file already exists' do
         before do
-          File.write(metadata.absolute_path, "---\nwho: knows")
+          metadata.absolute_path.write("---\nwho: knows")
         end
 
         it 'overwrites the file with the correct yaml' do
           metadata.save
 
-          expect(File.read(metadata.absolute_path)).to eq(<<YAML)
+          expect(metadata.absolute_path.read).to eq(<<YAML)
 ---
 favorite_color: blue
 YAML

--- a/spec/everything/piece/metadata_spec.rb
+++ b/spec/everything/piece/metadata_spec.rb
@@ -46,6 +46,21 @@ describe Everything::Piece::Metadata do
     end
   end
 
+  describe '#absolute_path' do
+    let(:metadata_absolute_path) do
+      '/fake/everything/path/grond-crawled-on/index.yaml'
+    end
+    it "returns the metadata's absolute path" do
+      expect(metadata.absolute_path).to eq(metadata_absolute_path)
+    end
+
+    it 'memoizes the value' do
+      first_call_result = metadata.absolute_path
+      second_call_result = metadata.absolute_path
+      expect(first_call_result.object_id).to eq(second_call_result.object_id)
+    end
+  end
+
   describe '#dir' do
     include_context 'with fake piece metadata'
 

--- a/spec/everything/piece/metadata_spec.rb
+++ b/spec/everything/piece/metadata_spec.rb
@@ -189,17 +189,17 @@ YAML
       end
 
       it 'creates the metadata yaml file' do
-        expect(File.exist?(metadata.file_path)).to eq(false)
+        expect(File.exist?(metadata.absolute_path)).to eq(false)
 
         metadata.save
 
-        expect(File.exist?(metadata.file_path)).to eq(true)
+        expect(File.exist?(metadata.absolute_path)).to eq(true)
       end
 
       it 'writes the yaml to the file' do
         metadata.save
 
-        expect(File.read(metadata.file_path)).to eq(<<YAML)
+        expect(File.read(metadata.absolute_path)).to eq(<<YAML)
 ---
 favorite_color: blue
 YAML
@@ -209,17 +209,17 @@ YAML
     context 'when the piece directory exists' do
       context 'when the metadata file does not exist' do
         it 'creates the metadata yaml file' do
-          expect(File.exist?(metadata.file_path)).to eq(false)
+          expect(File.exist?(metadata.absolute_path)).to eq(false)
 
           metadata.save
 
-          expect(File.exist?(metadata.file_path)).to eq(true)
+          expect(File.exist?(metadata.absolute_path)).to eq(true)
         end
 
         it 'writes the yaml to the file' do
           metadata.save
 
-          expect(File.read(metadata.file_path)).to eq(<<YAML)
+          expect(File.read(metadata.absolute_path)).to eq(<<YAML)
 ---
 favorite_color: blue
 YAML
@@ -228,13 +228,13 @@ YAML
 
       context 'when the metadata file already exists' do
         before do
-          File.write(metadata.file_path, "---\nwho: knows")
+          File.write(metadata.absolute_path, "---\nwho: knows")
         end
 
         it 'overwrites the file with the correct yaml' do
           metadata.save
 
-          expect(File.read(metadata.file_path)).to eq(<<YAML)
+          expect(File.read(metadata.absolute_path)).to eq(<<YAML)
 ---
 favorite_color: blue
 YAML

--- a/spec/everything/piece/metadata_spec.rb
+++ b/spec/everything/piece/metadata_spec.rb
@@ -37,6 +37,7 @@ describe Everything::Piece::Metadata do
     let(:metadata_absolute_dir) do
       Pathname.new('/fake/everything/path/grond-crawled-on')
     end
+
     it "returns the metadata's absolute path" do
       expect(metadata.absolute_dir).to eq(metadata_absolute_dir)
     end
@@ -54,6 +55,7 @@ describe Everything::Piece::Metadata do
     let(:metadata_absolute_path) do
       Pathname.new('/fake/everything/path/grond-crawled-on/index.yaml')
     end
+
     it "returns the metadata's absolute path" do
       expect(metadata.absolute_path).to eq(metadata_absolute_path)
     end
@@ -71,6 +73,7 @@ describe Everything::Piece::Metadata do
     let(:metadata_dir_relative_to_everything_path) do
       Pathname.new('grond-crawled-on')
     end
+
     it "returns the metadata's path relative to everything path" do
       expect(metadata.dir).to eq(metadata_dir_relative_to_everything_path)
     end
@@ -243,3 +246,4 @@ YAML
     end
   end
 end
+

--- a/spec/everything/piece/metadata_spec.rb
+++ b/spec/everything/piece/metadata_spec.rb
@@ -31,6 +31,21 @@ describe Everything::Piece::Metadata do
     end
   end
 
+  describe '#absolute_dir' do
+    let(:metadata_absolute_dir) do
+      '/fake/everything/path/grond-crawled-on'
+    end
+    it "returns the metadata's absolute path" do
+      expect(metadata.absolute_dir).to eq(metadata_absolute_dir)
+    end
+
+    it 'memoizes the value' do
+      first_call_result = metadata.absolute_dir
+      second_call_result = metadata.absolute_dir
+      expect(first_call_result.object_id).to eq(second_call_result.object_id)
+    end
+  end
+
   describe '#dir' do
     include_context 'with fake piece metadata'
 

--- a/spec/everything/piece_spec.rb
+++ b/spec/everything/piece_spec.rb
@@ -62,12 +62,11 @@ describe Everything::Piece do
   end
 
   describe '#dir' do
-
-    let(:piece_path_relative_to_everything_path) do
+    let(:piece_dir_relative_to_everything_path) do
       'here-is-our-piece'
     end
     it "returns the piece's path relative to everything path" do
-      expect(piece.dir).to eq(piece_path_relative_to_everything_path)
+      expect(piece.dir).to eq(piece_dir_relative_to_everything_path)
     end
 
     it 'memoizes the value' do
@@ -104,6 +103,28 @@ describe Everything::Piece do
 
     it 'is the last part of the path' do
       expect(piece.name).to eq(expected_name)
+    end
+
+    it 'memoizes the value' do
+      first_name_value = piece.name
+      second_name_value = piece.name
+      expect(first_name_value.object_id).to eq(second_name_value.object_id)
+    end
+  end
+
+  describe '#path' do
+    let(:piece_path_relative_to_everything_path) do
+      'here-is-our-piece/index.md'
+    end
+
+    it "returns the piece's path relative to everything path" do
+      expect(piece.path).to eq(piece_path_relative_to_everything_path)
+    end
+
+    it 'memoizes the value' do
+      first_path_value = piece.path
+      second_path_value = piece.path
+      expect(first_path_value.object_id).to eq(second_path_value.object_id)
     end
   end
 

--- a/spec/everything/piece_spec.rb
+++ b/spec/everything/piece_spec.rb
@@ -31,32 +31,26 @@ describe Everything::Piece do
   end
 
   describe '#absolute_dir' do
-    let(:piece_absolute_dir) do
-      '/fake/everything/path/grond-crawled-on'
-    end
-    it "returns the piece's absolute path" do
-      expect(piece.absolute_dir).to eq(piece_absolute_dir)
-    end
+    include_context 'with content double'
 
-    it 'memoizes the value' do
-      first_call_result = piece.absolute_dir
-      second_call_result = piece.absolute_dir
-      expect(first_call_result.object_id).to eq(second_call_result.object_id)
+    it 'delegates to the content' do
+      allow(content_double).to receive(:absolute_dir)
+
+      piece.absolute_dir
+
+      expect(content_double).to have_received(:absolute_dir)
     end
   end
 
   describe '#absolute_path' do
-    let(:piece_absolute_path) do
-      '/fake/everything/path/grond-crawled-on/index.md'
-    end
-    it "returns the piece's absolute path" do
-      expect(piece.absolute_path).to eq(piece_absolute_path)
-    end
+    include_context 'with content double'
 
-    it 'memoizes the value' do
-      first_call_result = piece.absolute_path
-      second_call_result = piece.absolute_path
-      expect(first_call_result.object_id).to eq(second_call_result.object_id)
+    it 'delegates to the content' do
+      allow(content_double).to receive(:absolute_path)
+
+      piece.absolute_path
+
+      expect(content_double).to have_received(:absolute_path)
     end
   end
 
@@ -87,18 +81,14 @@ describe Everything::Piece do
   end
 
   describe '#dir' do
-    # TODO: This should just delegate to content...
-    let(:piece_dir_relative_to_everything_path) do
-      'grond-crawled-on'
-    end
-    it "returns the piece's path relative to everything path" do
-      expect(piece.dir).to eq(piece_dir_relative_to_everything_path)
-    end
+    include_context 'with content double'
 
-    it 'memoizes the value' do
-      first_dir_value = piece.dir
-      second_dir_value = piece.dir
-      expect(first_dir_value.object_id).to eq(second_dir_value.object_id)
+    it 'delegates to the content' do
+      allow(content_double).to receive(:dir)
+
+      piece.dir
+
+      expect(content_double).to have_received(:dir)
     end
   end
 
@@ -151,18 +141,14 @@ describe Everything::Piece do
   end
 
   describe '#path' do
-    let(:piece_path_relative_to_everything_path) do
-      'grond-crawled-on/index.md'
-    end
+    include_context 'with content double'
 
-    it "returns the piece's path relative to everything path" do
-      expect(piece.path).to eq(piece_path_relative_to_everything_path)
-    end
+    it 'delegates to the content' do
+      allow(content_double).to receive(:path)
 
-    it 'memoizes the value' do
-      first_path_value = piece.path
-      second_path_value = piece.path
-      expect(first_path_value.object_id).to eq(second_path_value.object_id)
+      piece.path
+
+      expect(content_double).to have_received(:path)
     end
   end
 

--- a/spec/everything/piece_spec.rb
+++ b/spec/everything/piece_spec.rb
@@ -1,6 +1,11 @@
 describe Everything::Piece do
+  include_context 'with fake everything path env var'
+
+  let(:given_piece_name) do
+    'here-is-our-piece'
+  end
   let(:given_full_path) do
-    'some/fake/path/here-is-our-piece'
+    File.join(Everything.path, given_piece_name)
   end
   let(:piece) do
     described_class.new(given_full_path)
@@ -53,6 +58,22 @@ describe Everything::Piece do
         .with(given_full_path)
 
       piece.content
+    end
+  end
+
+  describe '#dir' do
+
+    let(:piece_path_relative_to_everything_path) do
+      'here-is-our-piece'
+    end
+    it "returns the piece's path relative to everything path" do
+      expect(piece.dir).to eq(piece_path_relative_to_everything_path)
+    end
+
+    it 'memoizes the value' do
+      first_dir_value = piece.dir
+      second_dir_value = piece.dir
+      expect(first_dir_value.object_id).to eq(second_dir_value.object_id)
     end
   end
 

--- a/spec/everything/piece_spec.rb
+++ b/spec/everything/piece_spec.rb
@@ -1,14 +1,9 @@
 describe Everything::Piece do
   include_context 'with fake everything path env var'
+  include_context 'with fake piece'
 
-  let(:given_piece_name) do
-    'here-is-our-piece'
-  end
-  let(:given_full_path) do
-    File.join(Everything.path, given_piece_name)
-  end
   let(:piece) do
-    described_class.new(given_full_path)
+    described_class.new(fake_piece_path)
   end
 
   shared_context 'with content double' do
@@ -37,7 +32,7 @@ describe Everything::Piece do
 
   describe '#absolute_dir' do
     let(:piece_absolute_dir) do
-      '/fake/everything/path/here-is-our-piece'
+      '/fake/everything/path/grond-crawled-on'
     end
     it "returns the piece's absolute path" do
       expect(piece.absolute_dir).to eq(piece_absolute_dir)
@@ -52,7 +47,7 @@ describe Everything::Piece do
 
   describe '#absolute_path' do
     let(:piece_absolute_path) do
-      '/fake/everything/path/here-is-our-piece/index.md'
+      '/fake/everything/path/grond-crawled-on/index.md'
     end
     it "returns the piece's absolute path" do
       expect(piece.absolute_path).to eq(piece_absolute_path)
@@ -85,15 +80,16 @@ describe Everything::Piece do
     it "is created with the piece's full path" do
       expect(Everything::Piece::Content)
         .to receive(:new)
-        .with(given_full_path)
+        .with(fake_piece_path)
 
       piece.content
     end
   end
 
   describe '#dir' do
+    # TODO: This should just delegate to content...
     let(:piece_dir_relative_to_everything_path) do
-      'here-is-our-piece'
+      'grond-crawled-on'
     end
     it "returns the piece's path relative to everything path" do
       expect(piece.dir).to eq(piece_dir_relative_to_everything_path)
@@ -120,7 +116,7 @@ describe Everything::Piece do
 
   describe '#full_path' do
     it "returns the piece's full path" do
-      expect(piece.full_path).to eq(given_full_path)
+      expect(piece.full_path).to eq(fake_piece_path)
     end
   end
 
@@ -132,7 +128,7 @@ describe Everything::Piece do
     it "is created with the piece's full path" do
       expect(Everything::Piece::Metadata)
         .to receive(:new)
-        .with(given_full_path)
+        .with(fake_piece_path)
 
       piece.metadata
     end
@@ -140,7 +136,7 @@ describe Everything::Piece do
 
   describe '#name' do
     let(:expected_name) do
-      'here-is-our-piece'
+      'grond-crawled-on'
     end
 
     it 'is the last part of the path' do
@@ -156,7 +152,7 @@ describe Everything::Piece do
 
   describe '#path' do
     let(:piece_path_relative_to_everything_path) do
-      'here-is-our-piece/index.md'
+      'grond-crawled-on/index.md'
     end
 
     it "returns the piece's path relative to everything path" do

--- a/spec/everything/piece_spec.rb
+++ b/spec/everything/piece_spec.rb
@@ -50,6 +50,21 @@ describe Everything::Piece do
     end
   end
 
+  describe '#absolute_path' do
+    let(:piece_absolute_path) do
+      '/fake/everything/path/here-is-our-piece/index.md'
+    end
+    it "returns the piece's absolute path" do
+      expect(piece.absolute_path).to eq(piece_absolute_path)
+    end
+
+    it 'memoizes the value' do
+      first_call_result = piece.absolute_path
+      second_call_result = piece.absolute_path
+      expect(first_call_result.object_id).to eq(second_call_result.object_id)
+    end
+  end
+
   describe '#body' do
     include_context 'with content double'
 

--- a/spec/everything/piece_spec.rb
+++ b/spec/everything/piece_spec.rb
@@ -76,6 +76,18 @@ describe Everything::Piece do
     end
   end
 
+  describe '#file_name' do
+    include_context 'with content double'
+
+    it 'delegates to the content' do
+      allow(content_double).to receive(:file_name)
+
+      piece.file_name
+
+      expect(content_double).to have_received(:file_name)
+    end
+  end
+
   describe '#full_path' do
     it "returns the piece's full path" do
       expect(piece.full_path).to eq(given_full_path)

--- a/spec/everything/piece_spec.rb
+++ b/spec/everything/piece_spec.rb
@@ -277,3 +277,4 @@ describe Everything::Piece do
     end
   end
 end
+

--- a/spec/everything/piece_spec.rb
+++ b/spec/everything/piece_spec.rb
@@ -35,6 +35,21 @@ describe Everything::Piece do
     end
   end
 
+  describe '#absolute_dir' do
+    let(:piece_absolute_dir) do
+      '/fake/everything/path/here-is-our-piece'
+    end
+    it "returns the piece's absolute path" do
+      expect(piece.absolute_dir).to eq(piece_absolute_dir)
+    end
+
+    it 'memoizes the value' do
+      first_call_result = piece.absolute_dir
+      second_call_result = piece.absolute_dir
+      expect(first_call_result.object_id).to eq(second_call_result.object_id)
+    end
+  end
+
   describe '#body' do
     include_context 'with content double'
 

--- a/spec/everything_spec.rb
+++ b/spec/everything_spec.rb
@@ -7,7 +7,7 @@ describe Everything do
     include_context 'with fake everything path env var'
 
     let(:expected_path) do
-      '/some/path/to/your/everything/repo/'
+      fake_everything_path
     end
 
     it 'is a pathname' do

--- a/spec/everything_spec.rb
+++ b/spec/everything_spec.rb
@@ -4,16 +4,10 @@ describe Everything do
   end
 
   describe '.path' do
+    include_context 'with fake everything path env var'
+
     let(:expected_path) do
       '/some/path/to/your/everything/repo/'
-    end
-
-    before do
-      without_partial_double_verification do
-        allow(Fastenv)
-          .to receive(:everything_path)
-          .and_return(expected_path)
-      end
     end
 
     it 'is a pathname' do

--- a/spec/everything_spec.rb
+++ b/spec/everything_spec.rb
@@ -9,11 +9,19 @@ describe Everything do
     end
 
     before do
-      ENV['EVERYTHING_PATH'] = expected_path
+      without_partial_double_verification do
+        allow(Fastenv)
+          .to receive(:everything_path)
+          .and_return(expected_path)
+      end
+    end
+
+    it 'is a pathname' do
+      expect(described_class.path).to be_a_kind_of(Pathname)
     end
 
     it 'is the path from the environment' do
-      expect(described_class.path).to eq(expected_path)
+      expect(described_class.path.to_s).to eq(expected_path)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,8 @@ require 'everything'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  require_relative 'support/shared'
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support/pieces.rb
+++ b/spec/support/pieces.rb
@@ -1,13 +1,61 @@
 require 'tmpdir'
 require 'fileutils'
 
-RSpec.shared_context 'with tmp piece on disk' do
-  let!(:tmp_piece_path) do
-    Dir.mktmpdir
+RSpec.shared_context 'with fake piece' do
+  include_context 'with fake everything path'
+
+  let(:fake_piece_path) do
+    File.join(Everything.path, 'fake-piece')
   end
 
-  after do
-    # This will recursively remove everything under that tmp dir.
-    FileUtils.remove_entry(tmp_piece_path)
+  before do
+    FileUtils.mkdir_p(fake_piece_path)
   end
+
+  # Folder will get cleaned up by fake everything path
+end
+
+RSpec.shared_context 'with fake piece content' do
+  include_context 'with fake piece'
+
+  let(:fake_piece_content_file_path) do
+    File.join(fake_piece_path, 'index.md')
+  end
+
+  let(:given_markdown) do
+    <<MD
+# Piece Title Here
+
+The body is totally this right here.
+
+And it might even include multiple lines!
+MD
+  end
+
+  before do
+    File.write(fake_piece_content_file_path, given_markdown)
+  end
+
+  # File will get cleaned up by fake everything path
+end
+
+RSpec.shared_context 'with fake piece metadata' do
+  include_context 'with fake piece'
+
+  let(:fake_piece_metadata_file_path) do
+    File.join(fake_piece_path, 'index.yaml')
+  end
+
+  let(:given_yaml) do
+    <<YAML
+---
+public: false
+YAML
+  end
+
+  before do
+    File.write(fake_piece_metadata_file_path, given_yaml)
+  end
+
+  # File will get cleaned up by fake everything path
 end

--- a/spec/support/pieces.rb
+++ b/spec/support/pieces.rb
@@ -1,4 +1,3 @@
-require 'tmpdir'
 require 'fileutils'
 
 RSpec.shared_context 'with fake piece' do

--- a/spec/support/pieces.rb
+++ b/spec/support/pieces.rb
@@ -8,7 +8,7 @@ RSpec.shared_context 'with fake piece' do
     'grond-crawled-on'
   end
   let(:fake_piece_path) do
-    File.join(Everything.path, given_piece_name)
+    Everything.path.join(given_piece_name)
   end
 
   before do
@@ -22,7 +22,7 @@ RSpec.shared_context 'with fake piece content' do
   include_context 'with fake piece'
 
   let(:fake_piece_content_file_path) do
-    File.join(fake_piece_path, 'index.md')
+    fake_piece_path.join('index.md')
   end
 
   let(:given_markdown) do
@@ -46,7 +46,7 @@ RSpec.shared_context 'with fake piece metadata' do
   include_context 'with fake piece'
 
   let(:fake_piece_metadata_file_path) do
-    File.join(fake_piece_path, 'index.yaml')
+    fake_piece_path.join('index.yaml')
   end
 
   let(:given_yaml) do

--- a/spec/support/pieces.rb
+++ b/spec/support/pieces.rb
@@ -4,8 +4,11 @@ require 'fileutils'
 RSpec.shared_context 'with fake piece' do
   include_context 'with fake everything path'
 
+  let(:given_piece_name) do
+    'grond-crawled-on'
+  end
   let(:fake_piece_path) do
-    File.join(Everything.path, 'fake-piece')
+    File.join(Everything.path, given_piece_name)
   end
 
   before do
@@ -59,3 +62,4 @@ YAML
 
   # File will get cleaned up by fake everything path
 end
+

--- a/spec/support/shared.rb
+++ b/spec/support/shared.rb
@@ -1,9 +1,13 @@
 shared_context 'with fake everything path env var' do
+  let(:fake_everything_path) do
+    '/fake/everything/path/'
+  end
+
   before do
     without_partial_double_verification do
       allow(Fastenv)
         .to receive(:everything_path)
-        .and_return(expected_path)
+        .and_return(fake_everything_path)
     end
   end
 end

--- a/spec/support/shared.rb
+++ b/spec/support/shared.rb
@@ -1,4 +1,4 @@
-shared_context 'with fake everything path env var' do
+RSpec.shared_context 'with fake everything path env var' do
   let(:fake_everything_path) do
     '/fake/everything/path/'
   end
@@ -11,3 +11,22 @@ shared_context 'with fake everything path env var' do
     end
   end
 end
+
+RSpec.shared_context 'with fake everything path' do
+  include FakeFS::SpecHelpers
+
+  include_context 'with fake everything path env var'
+
+  before do
+    FakeFS.activate!
+
+    FileUtils.mkdir_p(fake_everything_path)
+  end
+
+  after do
+    FileUtils.rm_rf(fake_everything_path)
+
+    FakeFS.deactivate!
+  end
+end
+

--- a/spec/support/shared.rb
+++ b/spec/support/shared.rb
@@ -1,0 +1,9 @@
+shared_context 'with fake everything path env var' do
+  before do
+    without_partial_double_verification do
+      allow(Fastenv)
+        .to receive(:everything_path)
+        .and_return(expected_path)
+    end
+  end
+end


### PR DESCRIPTION
Want to standardize how Everything classes reference dir and file paths.

And let's also use FakeFS for specs instead of creating temp dirs to create files on the real file system. That's dangerous and error-prone.